### PR TITLE
docs: explore qmd for semantic docs search

### DIFF
--- a/brainstorming/issue-069-qmd-docs-search/notes.md
+++ b/brainstorming/issue-069-qmd-docs-search/notes.md
@@ -1,0 +1,163 @@
+# Explore QMD for Better Docs Search
+
+**Issue**: [#69](https://github.com/FnSK4R17s/chakravarti-cli/issues/69)
+**Created**: 2026-03-02
+**Status**: Tasks Generated
+
+## Problem Statement
+
+Chakravarti CLI has ~50+ well-structured markdown docs (architecture, conventions, per-crate guides, command references, specs, brainstorms) but no way to semantically search them. Agents working on the codebase rely on file reads and grep, which misses conceptual matches.
+
+Example: an agent asking "how do I add a new agent" would need to know to look at `crates/docs/agent-guide.md` — grep for "add agent" might not find it.
+
+## Current State
+
+**Docs inventory:**
+
+| Location | Count | Content |
+|----------|-------|---------|
+| `crates/docs/` | 6 | Architecture, agent guide, CLI commands, getting started |
+| `crates/*/docs/README.md` | 13 | Per-crate documentation |
+| `crates/ckrv-cli/docs/commands/` | 21 | Auto-generated command docs |
+| Conventions files | 2 | `RUST_CONVENTIONS.md`, `FRONTEND_CONVENTIONS.md` |
+| `.agent/skills/*/SKILL.md` | 1 | Auto-generated agent skills |
+| `brainstorming/` | ~44 | Feature exploration notes |
+| `specs/` | ~170 | Feature specifications |
+
+**Current doc tooling:**
+- `just docs` → `cargo doc --no-deps --open` (rustdoc only)
+- `just skill` → generates SKILL.md from CLI metadata
+- `command_docs_gen` binary → auto-generates per-command markdown
+- 100% module doc coverage per health report
+
+**Pain points:**
+- No unified search across all markdown docs
+- Agents can't discover docs by concept, only by filename/keyword
+- No MCP interface for doc retrieval
+- `just docs` only opens rustdoc, doesn't surface markdown docs
+
+## Proposed Solution
+
+Integrate [qmd](https://github.com/tobi/qmd) — a local semantic search engine for markdown — to make all project docs queryable by both humans and AI agents.
+
+qmd provides:
+- **BM25 full-text search** (SQLite FTS5) for fast keyword matching
+- **Vector semantic search** using local GGUF embeddings
+- **LLM re-ranking** with query expansion for highest-quality results
+- **MCP server** so agents can query docs directly
+- **Collection management** with context metadata
+
+## User Stories
+
+### US1: Agent Doc Discovery
+**As a** Claude Code agent working on the chakravarti-cli codebase,
+**I want** to semantically search project documentation via MCP tools,
+**So that** I can find relevant architecture docs, conventions, and guides without knowing exact file paths.
+
+### US2: Developer Quick Search
+**As a** developer contributing to chakravarti-cli,
+**I want** to run `just docs-search "worktree isolation"` from the terminal,
+**So that** I can find relevant docs without manually browsing the directory tree.
+
+## Technical Approach
+
+### Options Considered
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **qmd** (selected) | Semantic + keyword search, MCP server, local-only, collection metadata | Node >= 22 required, ~2GB model download on first run |
+| Custom grep-based search | Zero dependencies, instant | No semantic search, keyword-only |
+| mdbook with search | Nice HTML site, built-in search | Keyword-only, heavy setup, doesn't help agents |
+
+### Decision
+
+**qmd** — it's the only option that provides semantic search AND an MCP server interface. The Node.js requirement is already met (v24.11.0 for frontend), and the `npx` invocation pattern matches our existing `.mcp.json` setup for chrome-devtools.
+
+## Implementation Notes
+
+### Installation: `npx` (no permanent install)
+- `npx -y @tobilu/qmd` — matches existing chrome-devtools MCP pattern
+- No root `package.json` needed (project is Rust-first)
+- Optional: `npm install -g @tobilu/qmd` for heavy users
+
+### 5 Collections
+
+| Collection | Path | Mask | Content |
+|------------|------|------|---------|
+| `ckrv-docs` | `./crates/` | `**/*.md` | Architecture, conventions, per-crate guides |
+| `ckrv-commands` | `./crates/ckrv-cli/docs/commands/` | `**/*.md` | Auto-generated CLI command docs |
+| `ckrv-specs` | `./specs/` | `**/*.md` | Feature specifications |
+| `ckrv-brainstorming` | `./brainstorming/` | `**/*.md` | Exploration notes |
+| `ckrv-root` | `./` | `*.md` (non-recursive) | README, CLAUDE.md, top-level docs |
+
+Each collection gets descriptive context metadata so qmd understands the hierarchy.
+
+### Files Modified (4 files, 0 new config files)
+
+1. **`.mcp.json`** — Add `qmd` MCP server entry alongside chrome-devtools
+2. **`.claude/settings.json`** — Pre-approve 6 read-only qmd MCP tool permissions
+3. **`.claude/settings.local.json`** — Add `"qmd"` to `enabledMcpjsonServers`
+4. **`justfile`** — Add `docs-*` recipes after existing DOCUMENTATION section
+
+### Justfile Recipes
+
+| Recipe | Purpose |
+|--------|---------|
+| `docs-index` | One-time setup: create collections, add context metadata, generate embeddings |
+| `docs-search <query>` | Fast BM25 keyword search |
+| `docs-vsearch <query>` | Semantic vector search |
+| `docs-query <query>` | Full hybrid + LLM re-ranking (best quality, slowest) |
+| `docs-reindex` | Refresh index after doc changes |
+| `docs-status` | Show index status |
+
+### MCP Tools Exposed to Agents
+
+All read-only, safe to pre-approve:
+- `qmd_search` — keyword search
+- `qmd_vector_search` — semantic search
+- `qmd_deep_search` — hybrid with re-ranking
+- `qmd_get` — fetch specific document
+- `qmd_multi_get` — fetch multiple documents by pattern
+- `qmd_status` — check index status
+
+### Indexing Strategy
+
+Manual indexing — `just docs-index` once, `just docs-reindex` after doc changes. No file watchers or build hooks because:
+- Embedding generation is slow (first run downloads ~2GB of models)
+- Docs change infrequently
+- qmd's SQLite index persists at `~/.cache/qmd/` across sessions
+
+## Open Questions
+
+- [ ] Should `just skill` chain to `docs-reindex` automatically?
+- [ ] Do we need all 5 collections, or would 2-3 (docs + specs + root) suffice to start?
+- [ ] Worth adding a `docs-mcp` recipe for HTTP daemon mode (useful for multi-agent setups)?
+
+## Success Criteria
+
+| Metric | Target |
+|--------|--------|
+| `just docs-search "orchestrator"` finds relevant docs | `crates/ckrv-core/docs/README.md`, `architecture.md` |
+| `just docs-vsearch "how do I add a new agent"` | Returns `agent-guide.md` in top 3 |
+| Claude Code agent can use `mcp__qmd__qmd_search` | Tools appear and are auto-approved |
+| No new config files in repo | qmd state stays in `~/.cache/qmd/` |
+
+## Vision Alignment
+
+From `vision.md`:
+> "Repos benefit from being agent-ready. Poorly documented codebases produce inconsistent results."
+
+qmd makes existing docs **discoverable** to agents without changing the docs themselves. It's infrastructure that improves agent effectiveness — aligned with ckrv's role as an orchestration layer.
+
+## Next Steps
+
+- [ ] Implement the 4-file change (`.mcp.json`, settings, justfile)
+- [ ] Run `just docs-index` and validate search results
+- [ ] Test MCP integration in a fresh Claude Code session
+- [ ] Document in `crates/docs/getting-started.md` (optional setup step)
+
+## References
+
+- [qmd GitHub](https://github.com/tobi/qmd)
+- [Issue #69](https://github.com/FnSK4R17s/chakravarti-cli/issues/69)
+- [Plan file](/home/sk4r/.claude/plans/nifty-gathering-wall.md) (session plan)

--- a/brainstorming/issue-069-qmd-docs-search/tasks.md
+++ b/brainstorming/issue-069-qmd-docs-search/tasks.md
@@ -1,0 +1,218 @@
+# Explore QMD for Better Docs Search - Tasks
+
+**Issue**: [#69](https://github.com/FnSK4R17s/chakravarti-cli/issues/69)
+**Brainstorm**: [notes.md](./notes.md)
+**Created**: 2026-03-02
+
+## Task Overview
+
+| Phase | Tasks | Estimate |
+|-------|-------|----------|
+| Phase 1: MCP & Permissions | 3 | 15m |
+| Phase 2: Justfile Recipes | 2 | 30m |
+| Phase 3: Index & Validate | 3 | 20m |
+| **Total** | **8** | **~1h** |
+
+> **Note**: First run of `just docs-index` will download ~2GB of GGUF models. This is a one-time cost not included in estimates.
+
+---
+
+## Dependencies
+
+```
+Phase 1 ──────────────────────────────────────────────►
+  Task 1.1 ──┬─► Task 1.2
+              └─► Task 1.3
+
+Phase 2 ──────────────────────────────────────────────►
+  Task 2.1 ──► Task 2.2
+
+Phase 3 (requires Phase 1 + 2) ──────────────────────►
+  Task 3.1 ──► Task 3.2 ──► Task 3.3
+```
+
+---
+
+## Phase 1: MCP & Permissions
+
+### Task 1.1: Add qmd MCP server to `.mcp.json`
+**Priority**: P0
+**Estimate**: 5m
+**Files**: `.mcp.json`
+
+Add a `qmd` entry alongside the existing `chrome-devtools` server. Use the same `npx -y` pattern.
+
+```json
+"qmd": {
+  "type": "stdio",
+  "command": "npx",
+  "args": ["-y", "@tobilu/qmd", "mcp"],
+  "env": {}
+}
+```
+
+**Acceptance Criteria**:
+- [ ] `.mcp.json` has `qmd` server entry
+- [ ] Uses `npx -y` pattern matching chrome-devtools
+- [ ] JSON is valid
+
+---
+
+### Task 1.2: Pre-approve qmd MCP tool permissions
+**Priority**: P0
+**Estimate**: 5m
+**Files**: `.claude/settings.json`
+
+Add all 6 qmd MCP tools to the `allow` array. All are read-only and safe to auto-approve.
+
+Tools to add:
+- `mcp__qmd__qmd_search`
+- `mcp__qmd__qmd_vector_search`
+- `mcp__qmd__qmd_deep_search`
+- `mcp__qmd__qmd_get`
+- `mcp__qmd__qmd_multi_get`
+- `mcp__qmd__qmd_status`
+
+**Acceptance Criteria**:
+- [ ] All 6 tool permissions added to `.claude/settings.json`
+- [ ] JSON is valid
+
+---
+
+### Task 1.3: Enable qmd in local settings
+**Priority**: P0
+**Estimate**: 5m
+**Files**: `.claude/settings.local.json`
+
+Add `"qmd"` to the `enabledMcpjsonServers` array.
+
+**Acceptance Criteria**:
+- [ ] `enabledMcpjsonServers` contains `"qmd"`
+- [ ] JSON is valid
+
+---
+
+## Phase 2: Justfile Recipes
+
+### Task 2.1: Add `docs-index` recipe
+**Priority**: P1
+**Estimate**: 20m
+**Files**: `justfile`
+
+Insert after the existing `docs` recipe (line ~257). This is the one-time setup recipe that creates 5 collections with context metadata and generates embeddings.
+
+**Collections to create:**
+
+| Collection | Path | Mask |
+|------------|------|------|
+| `ckrv-docs` | `./crates/` | `**/*.md` |
+| `ckrv-commands` | `./crates/ckrv-cli/docs/commands/` | `**/*.md` |
+| `ckrv-specs` | `./specs/` | `**/*.md` |
+| `ckrv-brainstorming` | `./brainstorming/` | `**/*.md` |
+| `ckrv-root` | `./` | `*.md` |
+
+**Context metadata for each:**
+- `/` → "Chakravarti CLI: spec-driven AI agent orchestration engine. Rust workspace with 13 crates."
+- `ckrv-docs` → "Core development documentation: architecture, conventions, per-crate guides"
+- `ckrv-commands` → "Auto-generated CLI command reference with flags, options, and exit codes"
+- `ckrv-specs` → "Feature specifications: plans, tasks, contracts, data models, checklists"
+- `ckrv-brainstorming` → "Feature exploration notes linked to GitHub issues"
+- `ckrv-root` → "Project overview, development guidelines, documentation system guide"
+
+Use `#!/usr/bin/env bash` with `set -euo pipefail`. End with `npx -y @tobilu/qmd embed`.
+
+**Acceptance Criteria**:
+- [ ] `just docs-index` creates all 5 collections
+- [ ] Context metadata set for each collection
+- [ ] Embeddings generated at the end
+- [ ] Uses `npx -y @tobilu/qmd` consistently
+
+---
+
+### Task 2.2: Add search and utility recipes
+**Priority**: P1
+**Estimate**: 10m
+**Files**: `justfile`
+
+Add these recipes after `docs-index`:
+
+| Recipe | Command |
+|--------|---------|
+| `docs-search query` | `npx -y @tobilu/qmd search "{{query}}" --md` |
+| `docs-vsearch query` | `npx -y @tobilu/qmd vsearch "{{query}}" --md` |
+| `docs-query query` | `npx -y @tobilu/qmd query "{{query}}" --md` |
+| `docs-reindex` | `npx -y @tobilu/qmd update && npx -y @tobilu/qmd embed` |
+| `docs-status` | `npx -y @tobilu/qmd status` |
+
+All use `--md` output format for human and agent readability.
+
+**Acceptance Criteria**:
+- [ ] All 5 recipes added to justfile
+- [ ] Each recipe has a descriptive comment
+- [ ] `just --list` shows all new recipes under DOCUMENTATION section
+- [ ] Recipes use `{{query}}` parameter syntax correctly
+
+---
+
+## Phase 3: Index & Validate
+
+### Task 3.1: Run initial indexing
+**Priority**: P1
+**Estimate**: 5m (excludes model download)
+**Files**: none (runtime only)
+
+Run `just docs-index` from project root. First run will:
+1. Download qmd via npx
+2. Download ~2GB of GGUF models
+3. Create 5 collections
+4. Generate embeddings for all docs
+
+**Acceptance Criteria**:
+- [ ] `just docs-index` completes without errors
+- [ ] `just docs-status` shows all 5 collections with document counts
+
+---
+
+### Task 3.2: Validate search quality
+**Priority**: P1
+**Estimate**: 10m
+**Files**: none (runtime only)
+
+Test all three search tiers:
+
+| Test | Command | Expected top result |
+|------|---------|---------------------|
+| Keyword | `just docs-search "orchestrator"` | `crates/ckrv-core/docs/README.md` |
+| Semantic | `just docs-vsearch "how do I add a new agent"` | `crates/docs/agent-guide.md` |
+| Hybrid | `just docs-query "worktree isolation and safety"` | `crates/ckrv-git/docs/README.md` |
+
+**Acceptance Criteria**:
+- [ ] All three search tiers return relevant results
+- [ ] `agent-guide.md` appears in top 3 for the semantic query
+- [ ] Output is readable markdown
+
+---
+
+### Task 3.3: Validate MCP integration
+**Priority**: P1
+**Estimate**: 5m
+**Files**: none (runtime only)
+
+Start a fresh Claude Code session in the project and verify:
+1. qmd MCP tools appear in the tool list
+2. Tools are auto-approved (no permission prompts)
+3. Agent can use `mcp__qmd__qmd_search` to find docs
+
+**Acceptance Criteria**:
+- [ ] qmd MCP server starts without errors
+- [ ] All 6 tools are accessible
+- [ ] No permission prompts for qmd tools
+- [ ] Search returns results within Claude Code session
+
+---
+
+## Post-Implementation
+
+After all tasks complete:
+- [ ] Update brainstorm status to "Archived"
+- [ ] Optionally add a "Doc Search" section to `crates/docs/getting-started.md`


### PR DESCRIPTION
## Summary
- Add brainstorm and task breakdown for integrating [qmd](https://github.com/tobi/qmd) as a semantic search engine over project markdown docs
- Proposes MCP server integration so agents can discover docs by concept, not just filename/keyword
- 8 tasks across 3 phases, ~1h estimated implementation

Closes #69

## Test plan
- [ ] Review brainstorm notes and task breakdown for completeness
- [ ] Validate proposed collection structure covers all doc locations
- [ ] Confirm qmd MCP tool names match actual package

🤖 Generated with [Claude Code](https://claude.com/claude-code)