### PR TITLE
fix(ci): switch release-please to simple type for workspace compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.6"
+version = "0.1.6" # x-release-please-version
 edition = "2021"
 authors = ["Chakravarti CLI Contributors"]
 license = "MIT"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,11 +1,19 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "simple",
   "include-component-in-tag": false,
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
+        {
+          "type": "generic",
+          "path": "Cargo.toml"
+        },
+        {
+          "type": "generic",
+          "path": "crates/ckrv-cli/Cargo.toml"
+        },
         {
           "type": "json",
           "path": "npm/package.json",
@@ -20,10 +28,6 @@
           "type": "json",
           "path": "crates/ckrv-tauri/tauri.conf.json",
           "jsonpath": "$.version"
-        },
-        {
-          "type": "generic",
-          "path": "crates/ckrv-cli/Cargo.toml"
         }
       ]
     }


### PR DESCRIPTION
## Summary

Fixes the Release Please workflow failure from #68 / PR #71.

The `rust` release type fails on workspace members that use `version.workspace = true` because the TOML parser expects a literal version string. Switches to `simple` release type and handles `Cargo.toml` via the generic updater with an `x-release-please-version` marker comment.

## Changes

- `release-please-config.json`: `rust` → `simple`, add root `Cargo.toml` as generic extra-file
- `Cargo.toml`: add `# x-release-please-version` marker on workspace version line

## Test plan

- [ ] Verify Release Please workflow succeeds on merge to main


🤖 Generated with [Claude Code](https://claude.com/claude-code)